### PR TITLE
Support complex path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ console.log(UNDEFINED_VAR === undefined) // true
 
 When `false` (default behavior), an error will be thrown.
 
+## Environment-based path
+
+You can optionally provide an object for the `path` option instead of a string.
+
+```json
+{
+  "plugins": [
+    ["dotenv-import", {
+      "path": {
+        "development": ".env.dev",
+        "production": ".env.prod"
+      }
+    }]
+  ]
+}
+```
+
+This will use a specific path based on `NODE_ENV`. For example, if `process.env.NODE_ENV` is `'development'`, then the `.env.dev` path will be used.
+
 ## Caveats
 
 When using with [`babel-loader`](https://github.com/babel/babel-loader) with caching enabled you will run into issues where environment changes won’t be picked up.

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ module.exports = ({types: t}) => ({
       allowUndefined: false
     }, this.opts)
 
+    if (typeof this.opts.path === 'object') {
+      this.opts.path = this.opts.path[process.env.NODE_ENV]
+    }
+
     if (this.opts.safe) {
       this.env = dotenv.parse(readFileSync(this.opts.path))
     } else {

--- a/test/fixtures/env-filename/.babelrc
+++ b/test/fixtures/env-filename/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["../../../", {
+      "path": {
+        "development": "test/fixtures/env-filename/.env.dev"
+      }
+    }]
+  ]
+}

--- a/test/fixtures/env-filename/.env.dev
+++ b/test/fixtures/env-filename/.env.dev
@@ -1,0 +1,1 @@
+API_KEY=dev-key

--- a/test/fixtures/env-filename/source.js
+++ b/test/fixtures/env-filename/source.js
@@ -1,0 +1,3 @@
+import {API_KEY} from '@env'
+
+console.log(API_KEY)

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,13 @@ test('load custom env file', t => {
   t.is(code, '\n\nconsole.log(\'abc123456\');\nconsole.log(\'username123456\');')
 })
 
+test('load custom env file based on NODE_ENV', t => {
+  process.env.NODE_ENV = 'development'
+
+  const {code} = transformFileSync('test/fixtures/env-filename/source.js')
+  t.is(code, '\n\nconsole.log(\'dev-key\');')
+})
+
 test('support `as alias` import syntax', t => {
   const {code} = transformFileSync('test/fixtures/as-alias/source.js')
   t.is(code, '\n\nconst a = \'abc123\';\nconst b = \'username\';')


### PR DESCRIPTION
This PR lets you use an object instead of a string for the `path` option.
Useful when you have multiple `.env` files based on your deployment environment. More info [here](https://github.com/motdotla/dotenv/issues/200#issuecomment-306008625).