### PR TITLE
feat: allowlisting which variables can be undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,26 @@ console.log(UNDEFINED_VAR === undefined) // true
 
 When `false` (default behavior), an error will be thrown.
 
+Alternatively, `allowUndefined` can be an array specifying the names of variables that are allowed to be `undefined`. Only the listed variables will be imported without errors if they are not defined, while others will still cause an error.
+
+```json
+{
+  "plugins": [
+    ["dotenv-import", {
+      "allowUndefined": ["ALLOWED_UNDEFINED_VAR"]
+    }]
+  ]
+}
+```
+
+```js
+import {ALLOWED_UNDEFINED_VAR, UNALLOWED_UNDEFINED} from '@env'
+
+console.log(ALLOWED_UNDEFINED_VAR === undefined) // true
+console.log(UNALLOWED_UNDEFINED) // Throws an error if not defined in .env
+```
+
+
 ## Caveats
 
 When using with [`babel-loader`](https://github.com/babel/babel-loader) with caching enabled you will run into issues where environment changes won’t be picked up.

--- a/__tests__/__fixtures__/undefined-allowlisted/.babelrc
+++ b/__tests__/__fixtures__/undefined-allowlisted/.babelrc
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    ["../../../", {
+      "allowUndefined": ["UNDEFINED_ALLOWLISTED"]
+    }]
+  ]
+}

--- a/__tests__/__fixtures__/undefined-allowlisted/source-allowlisted.js
+++ b/__tests__/__fixtures__/undefined-allowlisted/source-allowlisted.js
@@ -1,0 +1,3 @@
+import {UNDEFINED_ALLOWLISTED} from '@env'
+
+console.log(UNDEFINED_ALLOWLISTED)

--- a/__tests__/__fixtures__/undefined-allowlisted/source-undefined.js
+++ b/__tests__/__fixtures__/undefined-allowlisted/source-undefined.js
@@ -1,0 +1,3 @@
+import {UNDEFINED_UNLISTED} from '@env'
+
+console.log(UNDEFINED_UNLISTED)

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -99,6 +99,17 @@ describe('babel-plugin-dotenv-import', () => {
     expect(code).toBe('console.log(undefined);')
   })
 
+  it('should import allowlisted undefined variables', () => {
+    const {code} = transformFileSync(FIXTURES + 'undefined-allowlisted/source-allowlisted.js')
+    expect(code).toBe('console.log(undefined);')
+  })
+
+  it('should throw when trying to import an undefined variable that is not in the allowUndefined array', () => {
+    expect(() => transformFileSync(FIXTURES + 'undefined-allowlisted/source-undefined.js')).toThrow(
+      '"UNDEFINED_UNLISTED\" is not defined in .env or in allowUndefined[]'
+    )
+  })
+
   it('should not throw if .env exists in safe mode', () => {
     const {code} = transformFileSync(FIXTURES + 'safe-no-dotenv/source.js')
     expect(code).toBe('console.log(undefined);')

--- a/index.js
+++ b/index.js
@@ -67,7 +67,11 @@ module.exports = ({types: t}) => ({
             throw path.get('specifiers')[idx].buildCodeFrameError(`"${importedId}" was blocklisted`)
           }
 
-          if (!opts.allowUndefined && !Object.prototype.hasOwnProperty.call(this.env, importedId)) {
+          if (Array.isArray(opts.allowUndefined) && !Object.prototype.hasOwnProperty.call(this.env, importedId) && !opts.allowUndefined.includes(importedId)) {
+            throw path
+              .get('specifiers')
+              [idx].buildCodeFrameError(`"${importedId}" is not defined in ${opts.path} or in allowUndefined[]`)
+          } else if (!opts.allowUndefined && !Object.prototype.hasOwnProperty.call(this.env, importedId)) {
             throw path
               .get('specifiers')
               [idx].buildCodeFrameError(`"${importedId}" is not defined in ${opts.path}`)


### PR DESCRIPTION
This PR enables defining `allowUndefined` as an array of variables that will not throw even if the var is undefined. It doesn't change the behaviour when allowUndefined is `true` or `false`

```json
{
  "plugins": [
    ["dotenv-import", {
      "allowUndefined": ["ALLOWED_UNDEFINED_VAR"]
    }]
  ]
}
```